### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 <img src="images/light.svg" alt="Octomind Logo" width="150">
 
+<a href="https://glama.ai/mcp/servers/@OctoMind-dev/octomind-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OctoMind-dev/octomind-mcp/badge" alt="octomind-mcp MCP server" />
+</a>
+
 [![smithery badge](https://smithery.ai/badge/@OctoMind-dev/octomind-mcp)](https://smithery.ai/server/@OctoMind-dev/octomind-mcp)
 
 Octomind provides a whole e2e platform for test creation, execution and management including auto-fix.


### PR DESCRIPTION
This PR adds a badge for the [octomind-mcp](https://glama.ai/mcp/servers/@OctoMind-dev/octomind-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@OctoMind-dev/octomind-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OctoMind-dev/octomind-mcp/badge" alt="octomind-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.